### PR TITLE
PCA notebook for emission clustering

### DIFF
--- a/pca.ipynb
+++ b/pca.ipynb
@@ -1,0 +1,23 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c761efc2-c91a-4704-b436-f809d4d555aa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "",
+   "name": ""
+  },
+  "language_info": {
+   "name": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook applies PCA on greenhouse gas emissions data from 2000–2022 to identify key patterns and reduce dimensionality. Clustering will follow in a separate branch.